### PR TITLE
Fix tooltip clipping inside cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,7 +368,7 @@
 
     .page {
       position: relative;
-      overflow: hidden;
+      overflow: visible;
       isolation: isolate;
       flex: 1;
       display: flex;
@@ -483,7 +483,7 @@
       padding: clamp(16px, 2vw, 24px);
       box-shadow: var(--card-shadow);
       backdrop-filter: blur(16px);
-      overflow: hidden;
+      overflow: visible;
       transform: translateY(0);
       transition: transform 0.35s ease, box-shadow 0.4s ease, color 0.4s ease, background 0.4s ease;
     }
@@ -521,6 +521,7 @@
     .card:focus-within {
       transform: translateY(-4px);
       box-shadow: var(--card-shadow), 0 18px 36px rgba(77, 163, 255, 0.12);
+      z-index: 2;
     }
 
     .card:hover::before,


### PR DESCRIPTION
## Summary
- allow the main page and card containers to expose tooltip overflow so the info popovers are not clipped
- raise hovered or focused cards in the stacking order to keep their tooltips above neighboring sections

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df28afe424832ab03080be5c5b2ebc